### PR TITLE
docs(slack): add instructions for Slack to facilitate direct messaging the app

### DIFF
--- a/docs/apps/integrations/slack.md
+++ b/docs/apps/integrations/slack.md
@@ -3,7 +3,7 @@ id: slack
 title: Slack
 ---
 
-To call your Promptly app from a Slack channel, you need to first create a Slack app in your Slack workspace and use that configuration in your app's `Integration -> Slack` configuration. Follow the steps below to set up a Slack app to call your Promptly app.
+To call your Promptly app from Slack through app mentions in channels or by direct messaging the app, you need to first create a Slack app in your Slack workspace and use that configuration in your app's `Integration -> Slack` configuration. Follow the steps below to set up a Slack app to call your Promptly app.
 
 ![Slack Integration](/img/ui/slack.png)
 
@@ -11,7 +11,11 @@ To call your Promptly app from a Slack channel, you need to first create a Slack
 
 To create a Slack app, visit [https://api.slack.com/apps](https://api.slack.com/apps) and click the `Create New App` button. Pick `From scratch`, you’ll be prompted to give your app a name and select a workspace to install it in. Once you’ve done that, you’ll be taken to the app configuration page.
 
-Click on `OAuth & Permissions` under `Features` section in the sidebar and add the following scopes under `Bot Token Scopes` section:
+Click on `OAuth & Permissions` under `Features` section in the sidebar and add the following scopes under `Scopes` section:
+
+**Bot Token Scopes:** `app_mentions:read`, `channels:history`, `channels:read`, `chat:write`, `chat:write.customize`, `chat:write.public`, `commands`, `groups:history`, `im:history`, `im:read`, `im:write`, `incoming-webhook`, `mpim:history`, `mpim:read`, `mpim:write`, `users:read`, `users:read.email`
+
+**User Token Scopes:** `channels.read`, `chat.write`, `users.profile:read`, `users:read`
 
 Once added, click on `Install to Workspace` button under `OAuth Tokens for the workspace` section. You’ll be prompted to authorize the app to be installed in your workspace. Click `Allow` to install the app in your workspace. Once done, you’ll be taken back to the app configuration page where you can see `Bot User OAuth Token`.
 
@@ -27,6 +31,10 @@ Now go to your Slack app’s configuration page and click on `Event Subscription
 
 After this, you’ll need to subscribe to the following bot events under `Subscribe to Bot Events` section:
 
-`app_mention`
+`app_mention`, `message.channels`, `message.groups`, `message.im`, `message.mpim`.
 
-Click `Save Changes` to save the configuration. You’ll be prompted to reinstall the app in your workspace. Click `Reinstall App` to reinstall the app in your workspace. You should now be able to add the app to your Slack channels and call it from there which will trigger the LLM app and return the output.
+Click `Save Changes` to save the configuration. You’ll be prompted to reinstall the app in your workspace. Click `Reinstall App` to reinstall the app in your workspace. 
+
+To facilitate direct messaging with the app, access `App Home` under the `Features` section and activate the `Messages Tab` in the `Show Tabs` section.
+
+With these settings configured, you can now add the app to your Slack channels and interact with it. This interaction will activate the LLM app and return the output.


### PR DESCRIPTION
## Goal

To update instructions to connect your Promptly app from Slack through app mentions in channels or by direct messaging the app.

## References

https://github.com/trypromptly/LLMStack/pull/175

## Reviewers

@ajhai and @vegito22